### PR TITLE
Add the top-level domain as an environment variable to all docker containers

### DIFF
--- a/terraform/apps/docker-node-app/docker.tf
+++ b/terraform/apps/docker-node-app/docker.tf
@@ -28,7 +28,8 @@ resource "docker_container" "app_container" {
       "AWS_SECRET_ACCESS_KEY=${aws_iam_access_key.app_aws_key.secret}",
       "LISTENER_AUTH_TOKEN=${module.app_event_forwarder.auth_token}",
       "STREAM_NAME=${var.stream_name}",
-      "ARCHIVE_BUCKET=${var.archive_bucket_name}"
+      "ARCHIVE_BUCKET=${var.archive_bucket_name}",
+      "DOMAIN=${var.parent_domain_name}"
     ),
     "${var.env}"
   )}"]


### PR DESCRIPTION
Makes the domain available to apps in case they need it. Motivation for adding this is that the `group-mailer` will need this to validate incoming email requests. But it seems like a generally useful thing.

As a side note, the diff for this PR is a perfect example of why trailing commas are A Good Thing™! 😄 

<!---
@huboard:{"order":3.99997500249975,"milestone_order":10,"custom_state":""}
-->
