### PR TITLE
Add group-mailer app

### DIFF
--- a/terraform/apps/core.tf
+++ b/terraform/apps/core.tf
@@ -25,3 +25,5 @@ resource "random_id" "session_secret" {
   }
   byte_length = 32
 }
+
+# NOTE: If you add more resources here, they need to be added to the $CORE variable in the tf shell script

--- a/terraform/apps/docker-node-app/docker.tf
+++ b/terraform/apps/docker-node-app/docker.tf
@@ -24,6 +24,7 @@ resource "docker_container" "app_container" {
   }
   env = ["${concat(
     list(
+      "PORT=${var.port}",
       "AWS_ACCESS_KEY_ID=${aws_iam_access_key.app_aws_key.id}",
       "AWS_SECRET_ACCESS_KEY=${aws_iam_access_key.app_aws_key.secret}",
       "LISTENER_AUTH_TOKEN=${module.app_event_forwarder.auth_token}",

--- a/terraform/apps/group-mailer.tf
+++ b/terraform/apps/group-mailer.tf
@@ -1,8 +1,8 @@
-module "mailer_app" {
+module "group-mailer_app" {
   source = "./docker-node-app"
-  name = "mailer"
-  docker_image = "rabblerouser/mailer"
-  port = "3001"
+  name = "group-mailer"
+  docker_image = "rabblerouser/group-mailer"
+  port = "3002"
   host_ip = "${var.host_ip}"
   docker_api_key = "${var.docker_api_key}"
   docker_api_ca = "${var.docker_api_ca}"
@@ -16,19 +16,4 @@ module "mailer_app" {
   stream_name = "${var.stream_name}"
   archive_bucket_name = "${var.archive_bucket_name}"
   env = ["S3_EMAIL_BUCKET=TODO"]
-}
-
-resource "aws_iam_user_policy" "mailer_send_ses_email" {
-  name = "send_ses_email"
-  user = "${module.mailer_app.aws_user_name}"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [{
-      "Effect": "Allow",
-      "Action": "ses:SendEmail",
-      "Resource": "*"
-  }]
-}
-EOF
 }

--- a/terraform/apps/group-mailer.tf
+++ b/terraform/apps/group-mailer.tf
@@ -1,4 +1,4 @@
-module "group-mailer_app" {
+module "group_mailer_app" {
   source = "./docker-node-app"
   name = "group-mailer"
   docker_image = "rabblerouser/group-mailer"
@@ -15,5 +15,7 @@ module "group-mailer_app" {
   private_key_path = "${var.private_key_path}"
   stream_name = "${var.stream_name}"
   archive_bucket_name = "${var.archive_bucket_name}"
-  env = ["S3_EMAIL_BUCKET=TODO"]
+  env = ["S3_EMAIL_BUCKET=${var.domain}-mail-storage"]
 }
+
+# NOTE: If you add more resources here, they need to be added to the $GROUP_MAILER variable in the tf shell script

--- a/terraform/apps/group-mailer.tf
+++ b/terraform/apps/group-mailer.tf
@@ -15,7 +15,7 @@ module "group_mailer_app" {
   private_key_path = "${var.private_key_path}"
   stream_name = "${var.stream_name}"
   archive_bucket_name = "${var.archive_bucket_name}"
-  env = ["S3_EMAIL_BUCKET=${var.mail_bucket_name}"]
+  env = ["S3_EMAILS_BUCKET=${var.mail_bucket_name}"]
 }
 
 resource "aws_iam_user_policy" "group_mailer_read_mail_bucket" {

--- a/terraform/apps/group-mailer.tf
+++ b/terraform/apps/group-mailer.tf
@@ -15,7 +15,31 @@ module "group_mailer_app" {
   private_key_path = "${var.private_key_path}"
   stream_name = "${var.stream_name}"
   archive_bucket_name = "${var.archive_bucket_name}"
-  env = ["S3_EMAIL_BUCKET=${var.domain}-mail-storage"]
+  env = ["S3_EMAIL_BUCKET=${var.mail_bucket_name}"]
+}
+
+resource "aws_iam_user_policy" "group_mailer_read_mail_bucket" {
+  name = "group_mailer_read_mail_bucket"
+  user =  "${module.group_mailer_app.aws_user_name}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "${var.mail_bucket_arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "${var.mail_bucket_arn}/*"
+    }
+  ]
+}
+EOF
 }
 
 # NOTE: If you add more resources here, they need to be added to the $GROUP_MAILER variable in the tf shell script

--- a/terraform/apps/mailer.tf
+++ b/terraform/apps/mailer.tf
@@ -15,7 +15,7 @@ module "mailer_app" {
   private_key_path = "${var.private_key_path}"
   stream_name = "${var.stream_name}"
   archive_bucket_name = "${var.archive_bucket_name}"
-  env = ["S3_EMAIL_BUCKET=${var.mail_bucket_name}"]
+  env = ["S3_EMAILS_BUCKET=${var.mail_bucket_name}"]
 }
 
 resource "aws_iam_user_policy" "mailer_read_mail_bucket" {

--- a/terraform/apps/mailer.tf
+++ b/terraform/apps/mailer.tf
@@ -15,7 +15,7 @@ module "mailer_app" {
   private_key_path = "${var.private_key_path}"
   stream_name = "${var.stream_name}"
   archive_bucket_name = "${var.archive_bucket_name}"
-  env = ["S3_EMAIL_BUCKET=TODO"]
+  env = ["S3_EMAIL_BUCKET=${var.domain}-mail-storage"]
 }
 
 resource "aws_iam_user_policy" "mailer_send_ses_email" {
@@ -32,3 +32,5 @@ resource "aws_iam_user_policy" "mailer_send_ses_email" {
 }
 EOF
 }
+
+# NOTE: If you add more resources here, they need to be added to the $MAILER variable in the tf shell script

--- a/terraform/apps/mailer.tf
+++ b/terraform/apps/mailer.tf
@@ -15,7 +15,31 @@ module "mailer_app" {
   private_key_path = "${var.private_key_path}"
   stream_name = "${var.stream_name}"
   archive_bucket_name = "${var.archive_bucket_name}"
-  env = ["S3_EMAIL_BUCKET=${var.domain}-mail-storage"]
+  env = ["S3_EMAIL_BUCKET=${var.mail_bucket_name}"]
+}
+
+resource "aws_iam_user_policy" "mailer_read_mail_bucket" {
+  name = "mailer_read_mail_bucket"
+  user =  "${module.mailer_app.aws_user_name}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "${var.mail_bucket_arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "${var.mail_bucket_arn}/*"
+    }
+  ]
+}
+EOF
 }
 
 resource "aws_iam_user_policy" "mailer_send_ses_email" {

--- a/terraform/apps/variables.tf
+++ b/terraform/apps/variables.tf
@@ -57,3 +57,13 @@ variable "archive_bucket_name" {
   description = "The name of the event archive bucket"
   type = "string"
 }
+
+variable "mail_bucket_arn" {
+  description = "The ARN of the mail storage bucket"
+  type = "string"
+}
+
+variable "mail_bucket_name" {
+  description = "The name of the mail storage bucket"
+  type = "string"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,9 +28,11 @@ module apps {
   docker_api_ca = "${module.base.docker_api_ca}"
   docker_api_cert = "${module.base.docker_api_cert}"
   stream_arn = "${module.base.stream_arn}"
-  archive_bucket_arn = "${module.base.archive_bucket_arn}"
   stream_name = "${module.base.stream_name}"
+  archive_bucket_arn = "${module.base.archive_bucket_arn}"
   archive_bucket_name = "${module.base.archive_bucket_name}"
+  mail_bucket_arn = "arn:aws:s3:::${var.domain}-mail-storage" #TODO: Look up from the actual bucket resource
+  mail_bucket_name = "${var.domain}-mail-storage" #TODO: Look up from the actual bucket resource
 }
 
 module seeder {

--- a/terraform/tf
+++ b/terraform/tf
@@ -33,8 +33,8 @@ function usage() {
 BASE="--target module.base"
 APPS="--target module.apps"
 CORE="--target module.apps.module.core_app --target module.apps.random_id.session_secret"
-MAILER="--target module.apps.module.mailer_app --target module.apps.aws_iam_user_policy.mailer_send_ses_email"
-GROUP_MAILER="--target module.apps.module.group_mailer_app"
+MAILER="--target module.apps.module.mailer_app --target module.apps.aws_iam_user_policy.mailer_send_ses_email --target module.apps.aws_iam_user_policy.mailer_read_mail_bucket"
+GROUP_MAILER="--target module.apps.module.group_mailer_app --target module.apps.aws_iam_user_policy.group_mailer_read_mail_bucket"
 SEED="--target module.seeder"
 
 case "$1 $2" in

--- a/terraform/tf
+++ b/terraform/tf
@@ -12,6 +12,11 @@ if [[ -z `which aws` ]]; then
   exit 1
 fi
 
+if [[ -z `terraform version | grep v0.10` ]]; then
+  echo 'Error: This script should only be run with terraform v0.10'
+  exit 1
+fi
+
 function usage() {
   echo 'Usage:\n\t ./tf <COMMAND> [<MODULE>]'
   echo
@@ -27,8 +32,9 @@ function usage() {
 
 BASE="--target module.base"
 APPS="--target module.apps"
-CORE="--target module.apps.module.core_app --target module.apps.module.core_app.module.app_event_forwarder"
-MAILER="--target module.apps.module.mailer_app --target module.apps.module.mailer_app.module.app_event_forwarder"
+CORE="--target module.apps.module.core_app --target module.apps.random_id.session_secret"
+MAILER="--target module.apps.module.mailer_app --target module.apps.aws_iam_user_policy.mailer_send_ses_email"
+GROUP_MAILER="--target module.apps.module.group_mailer_app"
 SEED="--target module.seeder"
 
 case "$1 $2" in
@@ -42,7 +48,7 @@ case "$1 $2" in
     ;;
   "plan apps")
     set -x
-    eval terraform plan "$APPS" "$CORE" "$MAILER"
+    eval terraform plan "$APPS"
     ;;
   "plan seeder")
     set -x
@@ -52,8 +58,9 @@ case "$1 $2" in
   "apply ")
     set -x
     eval terraform apply "$BASE"
-    eval terraform apply "$APPS" "$CORE"
-    eval terraform apply "$APPS" "$MAILER"
+    eval terraform apply "$CORE"
+    eval terraform apply "$MAILER"
+    eval terraform apply "$GROUP_MAILER"
     ;;
   "apply base")
     set -x
@@ -61,8 +68,9 @@ case "$1 $2" in
     ;;
   "apply apps")
     set -x
-    eval terraform apply "$APPS" "$CORE"
-    eval terraform apply "$APPS" "$MAILER"
+    eval terraform apply "$CORE"
+    eval terraform apply "$MAILER"
+    eval terraform apply "$GROUP_MAILER"
     ;;
   "apply seeder")
     set -x


### PR DESCRIPTION
This deploys the `group-mailer` app.

There are a couple of TODOs here, because both the `mailer` and the `group-mailer` need the name of the S3 bucket where emails are stored. That S3 bucket is created by [this code](https://github.com/rabblerouser/group-mail-receiver/blob/master/terraform/s3.tf) which is in a different repo at the moment, which means this code here can't read the S3 bucket name.

So we either need to integrate the two somehow, or we could just live with the bucket name being specified in two different locations for the time being.

<!---
@huboard:{"custom_state":"archived"}
-->
