### PR TITLE
Make it easy to run docker commands against the remote daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .terraform
 terraform.tfstate
 terraform.tfstate.backup
+terraform/*.pem

--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ cd terraform
 ./tf
 ```
 
+## Reading the app logs
+
+See the next section on how to run arbitrary docker commands against the docker daemon running on the remote server.
+
+## Run docker commands remotely
+The EC2 instance has the docker remote API enabled, and you can interact with it using the regular docker client, just
+like you would when working with images and containers on your own machine. First run this command, which will set up
+a `dockerx` alias that's configured to run against the remote docker daemon:
+
+```sh
+cd terraform
+source enable-remote-docker.sh
+```
+
+Now you can use the alias to do things like watch the logs for a particular app:
+
+```sh
+dockerx logs -f group-mailer
+```
+
 ## SSH Access
 
 If the EC2 instance exists and your SSH public key is on it, you can use this helper script:

--- a/terraform/base/docker_auth.tf
+++ b/terraform/base/docker_auth.tf
@@ -6,7 +6,7 @@ resource "tls_self_signed_cert" "docker_ca" {
   key_algorithm = "${tls_private_key.docker_key.algorithm}"
   private_key_pem = "${tls_private_key.docker_key.private_key_pem}"
   subject {
-    common_name = "docker-ca.${var.domain}"
+    common_name = "${var.domain}"
   }
   ip_addresses = ["${aws_eip.eip.public_ip}"]
   validity_period_hours = "43800" # 5 years
@@ -24,7 +24,7 @@ resource "tls_cert_request" "docker_cert_request" {
   key_algorithm = "${tls_private_key.docker_key.algorithm}"
   private_key_pem = "${tls_private_key.docker_key.private_key_pem}"
   subject {
-    common_name = "docker.${var.domain}"
+    common_name = "${var.domain}"
   }
   ip_addresses = ["${aws_eip.eip.public_ip}"]
 }

--- a/terraform/enable-remote-docker.sh
+++ b/terraform/enable-remote-docker.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo -e '\033[0;31mError:\033[0m It looks like you are executing this script directly.'
+  echo 'Instead, you need to source it, like this:'
+  echo '    source enable-remote-docker.sh'
+  exit 1
+fi
+
+echo 'This script will enable an alias for running docker against a remote server.'
+echo 'Writing docker credentials to local files...'
+echo
+
+CA_PATH='./docker-ca.pem'
+CERT_PATH='./docker-cert.pem'
+KEY_PATH='./docker-key.pem'
+
+printf '[1/5] CA... '
+terraform output docker_api_ca > "${CA_PATH}"
+echo -e '\033[0;32mDone!\033[0m'
+printf '[2/5] Cert... '
+terraform output docker_api_cert > "${CERT_PATH}"
+echo -e '\033[0;32mDone!\033[0m'
+printf '[3/5] Key... '
+terraform output docker_api_key > "${KEY_PATH}"
+echo -e '\033[0;32mDone!\033[0m'
+
+printf '[4/5] Reading remote server IP address... '
+SERVER_IP=`terraform output host_ip`
+echo -e '\033[0;32mDone!\033[0m'
+
+printf '[5/5] Generating alias and verifying... '
+alias dockerx="docker --tlsverify -H=${SERVER_IP}:2376 --tlscacert=${CA_PATH} --tlscert=${CERT_PATH} --tlskey=${KEY_PATH}"
+dockerx ps > /dev/null
+echo -e '\033[0;32mDone!\033[0m'
+
+echo 'You can now execute docker commands against the remote API using `dockerx`. For example:'
+echo -e '    \033[1mdockerx ps\033[0m'
+echo -e '    \033[1mdockerx logs -f group-mailer\033[0m'
+echo -e '    \033[1mdockerx restart core\033[0m'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,7 +42,3 @@ module seeder {
   stream_arn = "${module.base.stream_arn}"
   stream_name = "${module.base.stream_name}"
 }
-
-output host_ip {
-  value = "${module.base.host_ip}"
-}

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,15 @@
+output host_ip {
+  value = "${module.base.host_ip}"
+}
+
+output "docker_api_key" {
+  value = "${module.base.docker_api_key}"
+}
+
+output "docker_api_ca" {
+  value = "${module.base.docker_api_ca}"
+}
+
+output "docker_api_cert" {
+  value = "${module.base.docker_api_cert}"
+}


### PR DESCRIPTION
1. Expose as outputs the key and certs that are generated for authenticating with the remote docker daemon
2. Fix the `common_name` field of those certs so that they match the actual domain where they get deployed to
3. Create a shell script that generates a docker alias which has its CLI flags set to run against the remote docker daemon
4. Document this capability

<!---
@huboard:{"custom_state":"archived"}
-->
