### PR TITLE
 Upgrade tf script to allow and require terraform version 0.11 

### DIFF
--- a/docs/existing_environment.md
+++ b/docs/existing_environment.md
@@ -33,14 +33,14 @@ terraform get
 
 ## Configure terraform remote state
 
-The current state of the infrastructure is stored in an S3 bucket. You need to tell terraform where it is (enter the given
-config values when prompted):
+The current state of the infrastructure is stored in an S3 bucket. You need to tell terraform where it is:
 
 ```sh
-terraform init
-#bucket: rr-staging.click-tf-state
-#key: terraform.tfstate
-#region: ap-southeast-2
+# Adjust the config if you're not trying to work on the RR team's staging environment
+terraform init \
+  --backend-config='bucket=rr-staging.click-tf-state' \
+  --backend-config='key=terraform.tfstate' \
+  --backend-config='region=ap-southeast-2'
 ```
 
 ## Run terraform

--- a/docs/new_environment.md
+++ b/docs/new_environment.md
@@ -95,20 +95,18 @@ file [`terraform/variables.tf`](../terraform/variables.tf), which can all be ove
 
 ## Create the base infrastructure
 
-Before you can deploy an application, you need to create the base infrastructure. Start with a dry run, and then if
-you're happy, create everything! *Note that this will cost you money, even if you have the AWS free tier*:
+Before you can deploy an application, you need to create the base infrastructure. *Note that this will cost you money,
+even if you have the AWS free tier*:
 
 ```sh
-./tf plan base
 ./tf apply base
 ```
 
 ## Deploy the apps
 
-Again, do a dry run, and then run it for real:
+Next we can deploy the applications onto the infrastructure:
 
 ```sh
-./tf plan apps
 ./tf apply apps
 ```
 
@@ -117,7 +115,6 @@ Again, do a dry run, and then run it for real:
 Before the application can be useful, the database needs some seed data. This is also done via terraform:
 
 ```sh
-./tf plan seeder
 ./tf apply seeder
 ```
 

--- a/terraform/tf
+++ b/terraform/tf
@@ -13,8 +13,8 @@ if [[ -z `which aws` ]]; then
   exit 1
 fi
 
-if [[ -z `terraform version | grep v0.10` ]]; then
-  echo 'Error: This script should only be run with terraform v0.10'
+if [[ -z `terraform version | grep v0.11` ]]; then
+  echo 'Error: This script should only be run with terraform v0.11'
   exit 1
 fi
 
@@ -36,8 +36,12 @@ APPS="--target module.apps"
 SEED="--target module.seeder"
 
 function run_terraform() {
-  # The sed command is to hide RSA keys/certs from stdout
-  eval terraform $@ | sed '/-----BEGIN/,/-----END/d'
+  # We pipe the terraform output through a couple of commands to hide sensitive SSL certificates
+  # The grep removes certs that are contained on a single line
+  # The sed removes certs that are spread across multiple lines
+  # TODO: Add the filtering back in. It causes problems now that `terraform apply` is interactive by default
+  # eval terraform $@ | grep -ve '-----BEGIN.*-----END' | sed '/-----BEGIN/,/-----END/d'
+  eval terraform $@
 }
 
 case "$1 $2" in


### PR DESCRIPTION
Resolves #13.

Unfortunately I had to take out the bit that filters sensitive info from the terraform output, as `grep` and `sed` don't seem to play nicely with the new interactive behaviour of `terraform apply` in terraform version 0.11.x.

I definitely want to figure it out and put the filtering back in, but for now I figured it was more important to keep terraform up to date. In the meantime, just, don't try to run the infra code anywhere where the logs are publicly available, like on travis CI or something like that.

<!---
@huboard:{"custom_state":"archived"}
-->
